### PR TITLE
Change to repository of Debian & EL Families

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,8 @@ jobs:
     strategy:
       max-parallel: 8
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, debian-buster, debian-stretch]
+        # IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,8 +46,7 @@ jobs:
     strategy:
       max-parallel: 8
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, debian-buster, debian-stretch]
-        # IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'feature_*'
+      - 'feature*'
+      - 'feature/*'
       - 'master'
   schedule:
     - cron: '0 0 * * *'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
 # EL family based
-speedtest_repo_el_url: https://bintray.com/ookla/rhel/rpm
+speedtest_repo_el_url: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_lsb['ansible_distribution_major_version'] }}/$basearch" ##https://bintray.com/ookla/rhel/rpm 
 speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
 speedtest_repo_el_filename_owner: root
 speedtest_repo_el_filename_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,8 @@ speedtest_debian_pre_reqs:
   - dirmngr
   - gnupg1
 speedtest_debian_pre_reqs_desired_state: present
-speedtest_repo_debian_gpg_key: 379CE192D401AB61
-speedtest_repo_debian: "deb https://ookla.bintray.com/debian generic main"
+speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
+speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
@@ -21,3 +21,5 @@ speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
 speedtest_repo_el_filename_owner: root
 speedtest_repo_el_filename_group: root
 speedtest_repo_el_filename_mode: '0644'
+# - darkwizard242.speedtest NEED TO FIX APT LINK deb https://packagecloud.io/ookla/speedtest-cli/ubuntu/ focal main
+# curl -s https://install.speedtest.net/app/cli/install.deb.sh | sudo bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,14 @@ speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
 # EL family based
-speedtest_repo_el_url: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch" ##https://bintray.com/ookla/rhel/rpm 
+speedtest_repo_el_name: ookla_speedtest-cli
+speedtest_repo_el_description: ookla_speedtest-cli
+speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch" ##https://bintray.com/ookla/rhel/rpm
+speedtest_repo_el_gpgcheck: no
+speedtest_repo_el_gpgkey: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
+speedtest_repo_el_state: present
+speedtest_repo_el_enabled: yes
 speedtest_repo_el_filename_owner: root
 speedtest_repo_el_filename_group: root
 speedtest_repo_el_filename_mode: '0644'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
 # EL family based
-speedtest_repo_el_url: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_lsb['ansible_distribution_major_version'] }}/$basearch" ##https://bintray.com/ookla/rhel/rpm 
+speedtest_repo_el_url: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch" ##https://bintray.com/ookla/rhel/rpm 
 speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
 speedtest_repo_el_filename_owner: root
 speedtest_repo_el_filename_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ speedtest_repo_el_description: ookla_speedtest-cli
 speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/el/{{ ansible_distribution_major_version }}/$basearch"
 speedtest_repo_el_gpgcheck: no
 speedtest_repo_el_gpgkey: https://packagecloud.io/ookla/speedtest-cli/gpgkey
-speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
+speedtest_repo_el_filename: "{{ speedtest_app }}"
 speedtest_repo_el_state: present
 speedtest_repo_el_enabled: yes
 speedtest_repo_el_filename_owner: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ speedtest_repo_debian_desired_state: present
 # EL family based
 speedtest_repo_el_name: ookla_speedtest-cli
 speedtest_repo_el_description: ookla_speedtest-cli
-speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch" ##https://bintray.com/ookla/rhel/rpm
+speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/el/{{ ansible_distribution_major_version }}/$basearch"
 speedtest_repo_el_gpgcheck: no
 speedtest_repo_el_gpgkey: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_el_filename: /etc/yum.repos.d/speedtest.repo
@@ -27,5 +27,3 @@ speedtest_repo_el_enabled: yes
 speedtest_repo_el_filename_owner: root
 speedtest_repo_el_filename_group: root
 speedtest_repo_el_filename_mode: '0644'
-# - darkwizard242.speedtest NEED TO FIX APT LINK deb https://packagecloud.io/ookla/speedtest-cli/ubuntu/ focal main
-# curl -s https://install.speedtest.net/app/cli/install.deb.sh | sudo bash

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -10,8 +10,7 @@
 
 - name: Debian/Ubuntu Family | Add gpg signing key for {{ speedtest_app }}
   apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: "{{ speedtest_repo_debian_gpg_key }}"
+    url: "{{ speedtest_repo_debian_gpg_key }}"
     state: present
 
 - name: Debian/Ubuntu Family | Adding repository {{ speedtest_repo_debian }}

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -2,10 +2,16 @@
 # tasks file for speedtest - EL Family
 
 
-- name: EL Family | Downloading official repository file from {{ speedtest_repo_el_url }}
-  get_url:
-    url: "{{ speedtest_repo_el_url }}"
-    dest: "{{ speedtest_repo_el_filename }}"
+- name: EL Family | Adding repository {{ speedtest_repo_el_url }}
+  yum_repository:
+    name: "{{ speedtest_repo_el_name }}"
+    description: "{{ speedtest_repo_el_description }}"
+    baseurl: "{{ speedtest_repo_el_baseurl }}"
+    gpgcheck: "{{ speedtest_repo_el_gpgcheck }}"
+    gpgkey: "{{ speedtest_repo_el_gpgkey }}"
+    file: "{{ speedtest_repo_el_filename }}"
+    state: "{{ speedtest_repo_el_state }}"
+    enabled: "{{ speedtest_repo_el_enabled }}"
     owner: "{{ speedtest_repo_el_filename_owner }}"
     group: "{{ speedtest_repo_el_filename_group }}"
     mode: "{{ speedtest_repo_el_filename_mode }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -1,8 +1,7 @@
 ---
 # tasks file for speedtest - EL Family
 
-
-- name: EL Family | Adding repository {{ speedtest_repo_el_url }}
+- name: EL Family | Adding repository {{ speedtest_repo_el_baseurl }}
   yum_repository:
     name: "{{ speedtest_repo_el_name }}"
     description: "{{ speedtest_repo_el_description }}"


### PR DESCRIPTION
## Debian family:
* Change for repository **URL**. Is **OS** and **version** based now and points to a different domain.
* Change for repository **GPG** key.

## EL family:
* Change for repository **URL**. Is **OS** and **version** based now and points to a different domain.
* Utilize `yum_repository` ansible module instead of `get_url`
* Setup of repository file.
* Change for repository GPG key.