### PR TITLE
Fix warning about deprecated /etc/apt/trusted.gpg on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,12 +66,13 @@ jobs:
         python-version: '3.10'
 
     - name: Update repo cache, install python3-setuptools and required pip modules
+      working-directory: '${{ env.CUSTOM_DIR }}'
       run: |
         sudo apt-get update
         sudo apt-get install python3-setuptools -y
         python3 -m venv ./venv
         . venv/bin/activate
-        pip3 install -U -r $CUSTOM_DIR/requirements.txt
+        pip3 install -U -r requirements.txt
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
       working-directory: '${{ env.CUSTOM_DIR }}'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,6 +69,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install python3-setuptools -y
+        python3 -m venv ./venv
+        . venv/bin/activate
         pip3 install -U -r $CUSTOM_DIR/requirements.txt
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,7 +75,9 @@ jobs:
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
       working-directory: '${{ env.CUSTOM_DIR }}'
-      run: DISTRO=${{ matrix.IMAGE }} molecule test
+      run: |
+        . venv/bin/activate
+        DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'
         ANSIBLE_FORCE_COLOR: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+molecule/default/tests/__pycache__
+venv

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgke
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}.gpg"
+speedtest_repo_debian_keyid: C525F88FCF3A7E56CE2CF59131EB3981E723ACAA
 speedtest_repo_debian_desired_state: present
 
 # EL family based
@@ -56,6 +57,7 @@ speedtest_repo_debian_gpg_key           | Speedtest GPG key url required on Debi
 speedtest_repo_debian                   | Speedtest repo URL for Debain family systems.
 speedtest_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
 speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`
+speedtest_repo_debian_keyid             | Key ID to import to ensure it hasn't changed. Download the key and use `gpg --show-keys <keyfile>` to determine the ID.
 speedtest_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **speedtest** package).
 speedtest_repo_el_name                  | Repository name for Speedtest on EL based systems.
 speedtest_repo_el_description           | Description to be added in EL based repository file for Speedtest.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ speedtest_debian_pre_reqs_desired_state: present
 speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
-speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}"
+speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}.gpg"
 speedtest_repo_debian_desired_state: present
 
 # EL family based
@@ -36,7 +36,7 @@ speedtest_repo_el_description: ookla_speedtest-cli
 speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/el/{{ ansible_distribution_major_version }}/$basearch"
 speedtest_repo_el_gpgcheck: no
 speedtest_repo_el_gpgkey: https://packagecloud.io/ookla/speedtest-cli/gpgkey
-speedtest_repo_el_filename: "{{ speedtest_app }}.gpg"
+speedtest_repo_el_filename: "{{ speedtest_app }}"
 speedtest_repo_el_state: present
 speedtest_repo_el_enabled: yes
 speedtest_repo_el_filename_owner: root
@@ -55,7 +55,7 @@ speedtest_debian_pre_reqs_desired_state | Desired state for Speedtest pre-requis
 speedtest_repo_debian_gpg_key           | Speedtest GPG key url required on Debian family systems
 speedtest_repo_debian                   | Speedtest repo URL for Debain family systems.
 speedtest_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
-speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems.
+speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`
 speedtest_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **speedtest** package).
 speedtest_repo_el_name                  | Repository name for Speedtest on EL based systems.
 speedtest_repo_el_description           | Description to be added in EL based repository file for Speedtest.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ speedtest_debian_pre_reqs_desired_state | Desired state for Speedtest pre-requis
 speedtest_repo_debian_gpg_key           | Speedtest GPG key url required on Debian family systems
 speedtest_repo_debian                   | Speedtest repo URL for Debain family systems.
 speedtest_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
-speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`.
+speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`
 speedtest_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **speedtest** package).
 speedtest_repo_el_name                  | Repository name for Speedtest on EL based systems.
 speedtest_repo_el_description           | Description to be added in EL based repository file for Speedtest.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ speedtest_debian_pre_reqs_desired_state | Desired state for Speedtest pre-requis
 speedtest_repo_debian_gpg_key           | Speedtest GPG key url required on Debian family systems
 speedtest_repo_debian                   | Speedtest repo URL for Debain family systems.
 speedtest_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
-speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`
+speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems. Should end in `.gpg`.
 speedtest_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **speedtest** package).
 speedtest_repo_el_name                  | Repository name for Speedtest on EL based systems.
 speedtest_repo_el_description           | Description to be added in EL based repository file for Speedtest.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ speedtest_debian_pre_reqs_desired_state: present
 speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
+speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
 # EL family based
@@ -35,7 +36,7 @@ speedtest_repo_el_description: ookla_speedtest-cli
 speedtest_repo_el_baseurl: "https://packagecloud.io/ookla/speedtest-cli/el/{{ ansible_distribution_major_version }}/$basearch"
 speedtest_repo_el_gpgcheck: no
 speedtest_repo_el_gpgkey: https://packagecloud.io/ookla/speedtest-cli/gpgkey
-speedtest_repo_el_filename: "{{ speedtest_app }}"
+speedtest_repo_el_filename: "{{ speedtest_app }}.gpg"
 speedtest_repo_el_state: present
 speedtest_repo_el_enabled: yes
 speedtest_repo_el_filename_owner: root
@@ -54,6 +55,7 @@ speedtest_debian_pre_reqs_desired_state | Desired state for Speedtest pre-requis
 speedtest_repo_debian_gpg_key           | Speedtest GPG key url required on Debian family systems
 speedtest_repo_debian                   | Speedtest repo URL for Debain family systems.
 speedtest_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
+speedtest_repo_debian_keyring_filename  | Name of the gpg file that will be stored at `/etc/apt/trusted.gpg.d/' on Debian based systems.
 speedtest_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **speedtest** package).
 speedtest_repo_el_name                  | Repository name for Speedtest on EL based systems.
 speedtest_repo_el_description           | Description to be added in EL based repository file for Speedtest.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ speedtest_debian_pre_reqs_desired_state: present
 speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
+speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_desired_state: present
 
 # EL family based

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgke
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
 speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}.gpg"
+speedtest_repo_debian_keyid: "C525F88FCF3A7E56CE2CF59131EB3981E723ACAA"
 speedtest_repo_debian_desired_state: present
 
 # EL family based

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ speedtest_debian_pre_reqs_desired_state: present
 speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
-speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}"
+speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}.gpg"
 speedtest_repo_debian_desired_state: present
 
 # EL family based

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,8 @@ speedtest_debian_pre_reqs_desired_state: present
 speedtest_repo_debian_gpg_key: https://packagecloud.io/ookla/speedtest-cli/gpgkey
 speedtest_repo_debian: "deb https://packagecloud.io/ookla/speedtest-cli/{{ ansible_distribution | lower }}/ {{ ansible_lsb['codename'] }} main"
 speedtest_repo_debian_filename: "{{ speedtest_app }}"
-speedtest_repo_debian_keyring_filename: "{{ speedtest_app }}.gpg"
-speedtest_repo_debian_keyid: "C525F88FCF3A7E56CE2CF59131EB3981E723ACAA"
+speedtest_repo_debian_keyring_filename: "/etc/apt/trusted.gpg.d/{{ speedtest_app }}.gpg"
+speedtest_repo_debian_keyid: C525F88FCF3A7E56CE2CF59131EB3981E723ACAA
 speedtest_repo_debian_desired_state: present
 
 # EL family based

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -11,6 +11,7 @@
 - name: Debian/Ubuntu Family | Add gpg signing key for {{ speedtest_app }}
   ansible.builtin.apt_key:
     url: "{{ speedtest_repo_debian_gpg_key }}"
+    keyring: "{{ speedtest_repo_debian_keyring_filename }}"
     state: present
 
 - name: Debian/Ubuntu Family | Adding repository {{ speedtest_repo_debian }}

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -12,6 +12,7 @@
   ansible.builtin.apt_key:
     url: "{{ speedtest_repo_debian_gpg_key }}"
     keyring: "{{ speedtest_repo_debian_keyring_filename }}"
+    id: "{{ speedtest_repo_debian_keyid }}"
     state: present
 
 - name: Debian/Ubuntu Family | Adding repository {{ speedtest_repo_debian }}


### PR DESCRIPTION
The old PR here: https://github.com/darkwizard242/ansible-role-speedtest/pull/5 was autoclosed when I renamed the branch.

Explanation from original PR:
After running this role on Ubuntu 22.04, it correctly installs the speedtest package (thanks for this role btw!), however, it leaves the system in a state where this warning shows upon the next apt update:

W: https://packagecloud.io/ookla/speedtest-cli/ubuntu/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.

This is because the gpg key which is imported is stored by default in /etc/apt/trusted.gpg instead of creating its own file entry in /etc/apt/trusted.gpg.d/

This PR adds a configuration variable which lets the user specify this filename, and defaults to storing in /etc/apt/trusted.gpg.d/speedtest.gpg which should prevent this warning from occuring in the future (the user may have to manually remove the /etc/apt/trusted.gpg file after running this patch though, but it will no longer be created for subsequent runs of the role.

See: https://github.com/darkwizard242/ansible-role-speedtest/pull/5#issuecomment-2048406505 for updated comment, re-opening with the suggested naming to see if the CI tests will pass or not.